### PR TITLE
Add callback function for remapping file descriptors.

### DIFF
--- a/src/argdata.h
+++ b/src/argdata.h
@@ -72,7 +72,12 @@ extern "C" {
 // the serialized data.
 // The data is not copied, only the pointer and size are stored in the
 // argdata_t object.
-argdata_t *argdata_from_buffer(const void *, size_t);
+// The convert_fd callback function is called when accessing file
+// descriptors. This function can be used to transform a file descriptor
+// number in the serialized data to its process-local value.
+argdata_t *argdata_from_buffer(const void *buf, size_t len,
+                               int (*convert_fd)(void *, size_t),
+                               void *convert_fd_arg);
 
 // Create an argdata_t representing a binary value.
 // The data is not copied, only the pointer and size are stored in the

--- a/src/argdata.h
+++ b/src/argdata.h
@@ -74,7 +74,8 @@ extern "C" {
 // argdata_t object.
 // The convert_fd callback function is called when accessing file
 // descriptors. This function can be used to transform a file descriptor
-// number in the serialized data to its process-local value.
+// number in the serialized data to its process-local value. In case
+// convert_fd is NULL, access to file descriptors is disallowed entirely.
 argdata_t *argdata_from_buffer(const void *buf, size_t len,
                                int (*convert_fd)(void *, size_t),
                                void *convert_fd_arg);

--- a/src/argdata.h
+++ b/src/argdata.h
@@ -160,8 +160,9 @@ int argdata_get_binary(const argdata_t *, const void **, size_t *);
 int argdata_get_bool(const argdata_t *, bool *);
 
 // Get the file descriptor represented by the argdata_t.
-// Returns 0 on success, or EINVAL if the argdata_t does not represent a file
-// descriptor.
+// Returns 0 on success, EINVAL if the argdata_t does not represent a
+// file descriptor, or EBADF if the file descriptor associated with the
+// object is not available within the current process.
 int argdata_get_fd(const argdata_t *, int *);
 
 // Get the floating point value of the argdata_t.

--- a/src/argdata.hpp
+++ b/src/argdata.hpp
@@ -51,7 +51,7 @@ struct argdata_t {
 		argdata_free(static_cast<argdata_t *>(p));
 	}
 
-	static std::unique_ptr<argdata_t> create_from_buffer(mstd::range<unsigned char const> r, int (*convert_fd)(void *, size_t), void *convert_fd_arg) {
+	static std::unique_ptr<argdata_t> create_from_buffer(mstd::range<unsigned char const> r, int (*convert_fd)(void *, size_t) = nullptr, void *convert_fd_arg = nullptr) {
 		return std::unique_ptr<argdata_t>(argdata_from_buffer(r.data(), r.size(), convert_fd, convert_fd_arg));
 	}
 	static std::unique_ptr<argdata_t> create_binary(mstd::range<unsigned char const> r) {

--- a/src/argdata.hpp
+++ b/src/argdata.hpp
@@ -51,8 +51,8 @@ struct argdata_t {
 		argdata_free(static_cast<argdata_t *>(p));
 	}
 
-	static std::unique_ptr<argdata_t> create_from_buffer(mstd::range<unsigned char const> r) {
-		return std::unique_ptr<argdata_t>(argdata_from_buffer(r.data(), r.size()));
+	static std::unique_ptr<argdata_t> create_from_buffer(mstd::range<unsigned char const> r, int (*convert_fd)(void *, size_t), void *convert_fd_arg) {
+		return std::unique_ptr<argdata_t>(argdata_from_buffer(r.data(), r.size(), convert_fd, convert_fd_arg));
 	}
 	static std::unique_ptr<argdata_t> create_binary(mstd::range<unsigned char const> r) {
 		return std::unique_ptr<argdata_t>(argdata_create_binary(r.data(), r.size()));

--- a/src/argdata_create_fd.c
+++ b/src/argdata_create_fd.c
@@ -25,9 +25,10 @@ argdata_t *argdata_create_fd(int value) {
   if (ad == NULL)
     return NULL;
 
-  // Store digits. File descriptors are stored as fixed length, so that
+  // File descriptors are stored as fixed length 32-bit numbers, so that
   // they can be substituted without causing the binary representation
-  // to change radically.
+  // to change radically. Just store the value zero for now, as the
+  // proper value will be filled in when serializing.
   uint8_t *bufstart = (uint8_t *)(ad + 1), *buf = bufstart;
   *buf++ = ADT_FD;
   encode_fd(0, &buf);

--- a/src/argdata_create_float.c
+++ b/src/argdata_create_float.c
@@ -34,8 +34,6 @@ argdata_t *argdata_create_float(double value) {
     bits >>= 8;
   }
 
-  ad->type = AD_BUFFER;
-  ad->buffer.buffer = buf;
-  ad->length = sizeof(uint64_t) + 1;
+  argdata_init_buffer(ad, buf, sizeof(uint64_t) + 1, NULL, NULL);
   return ad;
 }

--- a/src/argdata_create_float.c
+++ b/src/argdata_create_float.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -35,7 +35,7 @@ argdata_t *argdata_create_float(double value) {
   }
 
   ad->type = AD_BUFFER;
-  ad->buffer = buf;
+  ad->buffer.buffer = buf;
   ad->length = sizeof(uint64_t) + 1;
   return ad;
 }

--- a/src/argdata_create_int_s.c
+++ b/src/argdata_create_int_s.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -33,7 +33,7 @@ argdata_t *argdata_create_int_s(intmax_t value) {
   ++len;
 
   ad->type = AD_BUFFER;
-  ad->buffer = buf;
+  ad->buffer.buffer = buf;
   ad->length = len;
   return ad;
 }

--- a/src/argdata_create_int_s.c
+++ b/src/argdata_create_int_s.c
@@ -32,8 +32,6 @@ argdata_t *argdata_create_int_s(intmax_t value) {
   *--buf = ADT_INT;
   ++len;
 
-  ad->type = AD_BUFFER;
-  ad->buffer.buffer = buf;
-  ad->length = len;
+  argdata_init_buffer(ad, buf, len, NULL, NULL);
   return ad;
 }

--- a/src/argdata_create_int_u.c
+++ b/src/argdata_create_int_u.c
@@ -35,8 +35,6 @@ argdata_t *argdata_create_int_u(uintmax_t value) {
   *--buf = ADT_INT;
   ++len;
 
-  ad->type = AD_BUFFER;
-  ad->buffer.buffer = buf;
-  ad->length = len;
+  argdata_init_buffer(ad, buf, len, NULL, NULL);
   return ad;
 }

--- a/src/argdata_create_int_u.c
+++ b/src/argdata_create_int_u.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -36,7 +36,7 @@ argdata_t *argdata_create_int_u(uintmax_t value) {
   ++len;
 
   ad->type = AD_BUFFER;
-  ad->buffer = buf;
+  ad->buffer.buffer = buf;
   ad->length = len;
   return ad;
 }

--- a/src/argdata_create_timestamp.c
+++ b/src/argdata_create_timestamp.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -51,7 +51,7 @@ argdata_t *argdata_create_timestamp(const struct timespec *ts) {
   *--buf = ADT_TIMESTAMP;
 
   ad->type = AD_BUFFER;
-  ad->buffer = buf;
+  ad->buffer.buffer = buf;
   ad->length = buf_end - buf;
   return ad;
 }

--- a/src/argdata_create_timestamp.c
+++ b/src/argdata_create_timestamp.c
@@ -50,8 +50,6 @@ argdata_t *argdata_create_timestamp(const struct timespec *ts) {
     ++buf;
   *--buf = ADT_TIMESTAMP;
 
-  ad->type = AD_BUFFER;
-  ad->buffer.buffer = buf;
-  ad->length = buf_end - buf;
+  argdata_init_buffer(ad, buf, buf_end - buf, NULL, NULL);
   return ad;
 }

--- a/src/argdata_false.c
+++ b/src/argdata_false.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -10,5 +10,5 @@
 static const uint8_t buf_false[] = {ADT_BOOL};
 
 const argdata_t argdata_false = {
-    .type = AD_BUFFER, .buffer = buf_false, .length = sizeof(buf_false),
+    .type = AD_BUFFER, .buffer.buffer = buf_false, .length = sizeof(buf_false),
 };

--- a/src/argdata_from_buffer.c
+++ b/src/argdata_from_buffer.c
@@ -7,12 +7,20 @@
 
 #include "argdata_impl.h"
 
+// In case no file descriptor conversion function is provided, simply
+// disallow access to any of the process-local file descriptors.
+static int disallow_fd_access(void *arg, size_t fd) {
+  return -1;
+}
+
 argdata_t *argdata_from_buffer(const void *buf, size_t len,
                                int (*convert_fd)(void *, size_t),
                                void *convert_fd_arg) {
   argdata_t *ad = malloc(sizeof(*ad));
   if (ad == NULL)
     return NULL;
-  argdata_init_buffer(ad, buf, len, convert_fd, convert_fd_arg);
+  argdata_init_buffer(ad, buf, len,
+                      convert_fd != NULL ? convert_fd : disallow_fd_access,
+                      convert_fd_arg);
   return ad;
 }

--- a/src/argdata_from_buffer.c
+++ b/src/argdata_from_buffer.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -7,10 +7,12 @@
 
 #include "argdata_impl.h"
 
-argdata_t *argdata_from_buffer(const void *buf, size_t len) {
+argdata_t *argdata_from_buffer(const void *buf, size_t len,
+                               int (*convert_fd)(void *, size_t),
+                               void *convert_fd_arg) {
   argdata_t *ad = malloc(sizeof(*ad));
   if (ad == NULL)
     return NULL;
-  argdata_init_buffer(ad, buf, len);
+  argdata_init_buffer(ad, buf, len, convert_fd, convert_fd_arg);
   return ad;
 }

--- a/src/argdata_get_binary.c
+++ b/src/argdata_get_binary.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -11,7 +11,7 @@ int argdata_get_binary(const argdata_t *ad, const void **value,
                        size_t *valuelen) {
   switch (ad->type) {
     case AD_BUFFER: {
-      const uint8_t *buf = ad->buffer;
+      const uint8_t *buf = ad->buffer.buffer;
       size_t len = ad->length;
       int error = parse_type(ADT_BINARY, &buf, &len);
       if (error != 0)

--- a/src/argdata_get_bool.c
+++ b/src/argdata_get_bool.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -11,7 +11,7 @@
 int argdata_get_bool(const argdata_t *ad, bool *value) {
   switch (ad->type) {
     case AD_BUFFER: {
-      const uint8_t *buf = ad->buffer;
+      const uint8_t *buf = ad->buffer.buffer;
       size_t len = ad->length;
       int error = parse_type(ADT_BOOL, &buf, &len);
       if (error != 0)

--- a/src/argdata_get_fd.c
+++ b/src/argdata_get_fd.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -11,14 +11,24 @@
 int argdata_get_fd(const argdata_t *ad, int *value) {
   switch (ad->type) {
     case AD_BUFFER: {
-      const uint8_t *buf = ad->buffer;
+      const uint8_t *buf = ad->buffer.buffer;
       size_t len = ad->length;
       int error = parse_type(ADT_FD, &buf, &len);
       if (error != 0)
         return error;
 
-      // Extract file descriptor number.
-      return parse_fd(value, &buf, &len);
+      // Extract raw file descriptor number.
+      uint32_t raw_fd;
+      error = parse_fd(&raw_fd, &buf, &len);
+      if (error != 0)
+        return error;
+
+      // Convert it to a process-local file descriptor number.
+      int fd = ad->buffer.convert_fd(ad->buffer.convert_fd_arg, raw_fd);
+      if (fd < 0)
+        return EINVAL;
+      *value = fd;
+      return 0;
     }
     default:
       return EINVAL;

--- a/src/argdata_get_fd.c
+++ b/src/argdata_get_fd.c
@@ -26,7 +26,7 @@ int argdata_get_fd(const argdata_t *ad, int *value) {
       // Convert it to a process-local file descriptor number.
       int fd = ad->buffer.convert_fd(ad->buffer.convert_fd_arg, raw_fd);
       if (fd < 0)
-        return EINVAL;
+        return EBADF;
       *value = fd;
       return 0;
     }

--- a/src/argdata_get_float.c
+++ b/src/argdata_get_float.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -11,7 +11,7 @@
 int argdata_get_float(const argdata_t *ad, double *value) {
   switch (ad->type) {
     case AD_BUFFER: {
-      const uint8_t *buf = ad->buffer;
+      const uint8_t *buf = ad->buffer.buffer;
       size_t len = ad->length;
       int error = parse_type(ADT_FLOAT, &buf, &len);
       if (error != 0)

--- a/src/argdata_get_int_s.c
+++ b/src/argdata_get_int_s.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -12,7 +12,7 @@ int argdata_get_int_s(const argdata_t *ad, intmax_t *value, intmax_t min,
                       intmax_t max) {
   switch (ad->type) {
     case AD_BUFFER: {
-      const uint8_t *buf = ad->buffer;
+      const uint8_t *buf = ad->buffer.buffer;
       size_t len = ad->length;
       int error = parse_type(ADT_INT, &buf, &len);
       if (error != 0)

--- a/src/argdata_get_int_u.c
+++ b/src/argdata_get_int_u.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -11,7 +11,7 @@
 int argdata_get_int_u(const argdata_t *ad, uintmax_t *value, uintmax_t max) {
   switch (ad->type) {
     case AD_BUFFER: {
-      const uint8_t *buf = ad->buffer;
+      const uint8_t *buf = ad->buffer.buffer;
       size_t len = ad->length;
       int error = parse_type(ADT_INT, &buf, &len);
       if (error != 0)

--- a/src/argdata_get_str.c
+++ b/src/argdata_get_str.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -10,7 +10,7 @@
 int argdata_get_str(const argdata_t *ad, const char **value, size_t *valuelen) {
   switch (ad->type) {
     case AD_BUFFER: {
-      const uint8_t *buf = ad->buffer;
+      const uint8_t *buf = ad->buffer.buffer;
       size_t len = ad->length;
       int error = parse_type(ADT_STR, &buf, &len);
       if (error != 0)

--- a/src/argdata_get_timestamp.c
+++ b/src/argdata_get_timestamp.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -43,7 +43,7 @@
 int argdata_get_timestamp(const argdata_t *ad, struct timespec *value) {
   switch (ad->type) {
     case AD_BUFFER: {
-      const uint8_t *buf = ad->buffer;
+      const uint8_t *buf = ad->buffer.buffer;
       size_t len = ad->length;
       int error = parse_type(ADT_TIMESTAMP, &buf, &len);
       if (error != 0)

--- a/src/argdata_impl.h
+++ b/src/argdata_impl.h
@@ -205,7 +205,7 @@ static inline int parse_fd(uint32_t *value, const uint8_t **buf, size_t *len) {
   return 0;
 }
 
-static inline void encode_fd(int value, uint8_t **buf) {
+static inline void encode_fd(uint32_t value, uint8_t **buf) {
   *(*buf)++ = value >> 24;
   *(*buf)++ = value >> 16;
   *(*buf)++ = value >> 8;

--- a/src/argdata_map_iterate.c
+++ b/src/argdata_map_iterate.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Nuxi (https://nuxi.nl/) and contributors.
+// Copyright (c) 2016-2017 Nuxi (https://nuxi.nl/) and contributors.
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -13,8 +13,10 @@ int argdata_map_iterate(const argdata_t *ad, argdata_map_iterator_t *it_) {
       (struct argdata_map_iterator_impl *)it_;
   switch (ad->type) {
     case AD_BUFFER:
-      it->buf = ad->buffer;
+      it->buf = ad->buffer.buffer;
       it->len = ad->length;
+      it->convert_fd = ad->buffer.convert_fd;
+      it->convert_fd_arg = ad->buffer.convert_fd_arg;
       it->error = parse_type(ADT_MAP, &it->buf, &it->len);
       it->values = NULL;
       break;

--- a/src/argdata_map_next.c
+++ b/src/argdata_map_next.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Nuxi (https://nuxi.nl/) and contributors.
+// Copyright (c) 2016-2017 Nuxi (https://nuxi.nl/) and contributors.
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -16,12 +16,14 @@ bool argdata_map_next(argdata_map_iterator_t *it_, const argdata_t **key,
   if (it->len == 0)
     return false;
   if (it->values == NULL) {
-    int error = parse_subfield(&it->key, &it->buf, &it->len);
+    int error = parse_subfield(&it->key, &it->buf, &it->len, it->convert_fd,
+                               it->convert_fd_arg);
     if (error != 0) {
       it->error = error;
       return false;
     }
-    error = parse_subfield(&it->value, &it->buf, &it->len);
+    error = parse_subfield(&it->value, &it->buf, &it->len, it->convert_fd,
+                           it->convert_fd_arg);
     if (error != 0) {
       it->error = error;
       return false;

--- a/src/argdata_null.c
+++ b/src/argdata_null.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -8,5 +8,5 @@
 #include "argdata_impl.h"
 
 const argdata_t argdata_null = {
-    .type = AD_BUFFER, .buffer = NULL, .length = 0,
+    .type = AD_BUFFER, .buffer.buffer = NULL, .length = 0,
 };

--- a/src/argdata_print_yaml.c
+++ b/src/argdata_print_yaml.c
@@ -3,6 +3,7 @@
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
 
+#include <errno.h>
 #include <float.h>
 #include <inttypes.h>
 #include <locale.h>
@@ -73,9 +74,13 @@ static void print_yaml(const argdata_t *ad, FILE *fp, unsigned int depth) {
   // Extension: file descriptors.
   {
     int value;
-    if (argdata_get_fd(ad, &value) == 0) {
-      fprintf(fp, "!fd \"%d\"", value);
-      return;
+    switch (argdata_get_fd(ad, &value)) {
+      case 0:
+        fprintf(fp, "!fd \"%d\"", value);
+        return;
+      case EBADF:
+        fprintf(fp, "!fd \"invalid\"");
+        return;
     }
   }
 

--- a/src/argdata_seq_iterate.c
+++ b/src/argdata_seq_iterate.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Nuxi (https://nuxi.nl/) and contributors.
+// Copyright (c) 2016-2017 Nuxi (https://nuxi.nl/) and contributors.
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -13,8 +13,10 @@ int argdata_seq_iterate(const argdata_t *ad, argdata_seq_iterator_t *it_) {
       (struct argdata_seq_iterator_impl *)it_;
   switch (ad->type) {
     case AD_BUFFER:
-      it->buf = ad->buffer;
+      it->buf = ad->buffer.buffer;
       it->len = ad->length;
+      it->convert_fd = ad->buffer.convert_fd;
+      it->convert_fd_arg = ad->buffer.convert_fd_arg;
       it->error = parse_type(ADT_SEQ, &it->buf, &it->len);
       it->entries = NULL;
       break;

--- a/src/argdata_seq_next.c
+++ b/src/argdata_seq_next.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Nuxi (https://nuxi.nl/) and contributors.
+// Copyright (c) 2016-2017 Nuxi (https://nuxi.nl/) and contributors.
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -15,7 +15,8 @@ bool argdata_seq_next(argdata_seq_iterator_t *it_, const argdata_t **value) {
   if (it->len == 0)
     return false;
   if (it->entries == NULL) {
-    int error = parse_subfield(&it->value, &it->buf, &it->len);
+    int error = parse_subfield(&it->value, &it->buf, &it->len, it->convert_fd,
+                               it->convert_fd_arg);
     if (error != 0) {
       it->error = error;
       return false;

--- a/src/argdata_serialized_length.c
+++ b/src/argdata_serialized_length.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -14,7 +14,7 @@ static size_t countfds(const argdata_t *ad) {
 
   switch (ad->type) {
     case AD_BUFFER: {
-      const uint8_t *ibuf = ad->buffer;
+      const uint8_t *ibuf = ad->buffer.buffer;
       size_t ilen = ad->length - 1;
 
       switch (*ibuf++) {
@@ -25,14 +25,15 @@ static size_t countfds(const argdata_t *ad) {
           size_t fdslen = 0;
           for (;;) {
             argdata_t iad;
-            if (parse_subfield(&iad, &ibuf, &ilen) != 0)
+            if (parse_subfield(&iad, &ibuf, &ilen, ad->buffer.convert_fd,
+                               ad->buffer.convert_fd_arg) != 0)
               return fdslen;
             fdslen += countfds(&iad);
           }
         }
         case ADT_FD: {
           // A file descriptor.
-          int fd;
+          uint32_t fd;
           return parse_fd(&fd, &ibuf, &ilen) == 0 ? 1 : 0;
         }
         default:

--- a/src/argdata_true.c
+++ b/src/argdata_true.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Nuxi, https://nuxi.nl/
+// Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
 //
 // This file is distributed under a 2-clause BSD license.
 // See the LICENSE file for details.
@@ -10,5 +10,5 @@
 static const uint8_t buf_true[] = {ADT_BOOL, 1};
 
 const argdata_t argdata_true = {
-    .type = AD_BUFFER, .buffer = buf_true, .length = sizeof(buf_true),
+    .type = AD_BUFFER, .buffer.buffer = buf_true, .length = sizeof(buf_true),
 };


### PR DESCRIPTION
When using Argdata as a serialization mechanism for RPCs, file descriptors on the receiving side are unlikely to be numbered sequentially, starting at zero. Extend `argdata_from_buffer()`, so that file descriptor numbers stored in the serialized data can be converted to a process-local file descriptor number.

The `argdata_get_fd()` function has now been extended to return `EBADF` in case a node does correspond with a file descriptor, but the callback function doesn't return a valid file descriptor. This allows users of the library to distinguish between typing errors and the absence of file descriptors.

During the serialization process, we now also encode any invalid file descriptors as `\x03\xff\xff\xff\xff` (`UINT32_MAX`). Under the assumption that `INT_MAX < UINT32_MAX`, it is impossible that this index is ever used. This scheme has the advantage that if data with bad file descriptors is serialized and deserialized, such nodes will still be reported as being invalid.